### PR TITLE
ITOP-3207 Allow to configure tomcat valves and listeners

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,14 @@ RUN apt-get -qq update && \
   apt-get -qq -y install ${_APT_OPTIONS} libreoffice-calc libreoffice-draw libreoffice-impress libreoffice-math libreoffice-writer && \
   apt-get -qq -y autoremove && \
   apt-get -qq -y clean && \
-  rm -rf /var/lib/apt/lists/*
+  rm -rf /var/lib/apt/lists/* && \
+  wget -q -O /usr/bin/yaml https://github.com/mikefarah/yaml/releases/download/1.10/yaml_linux_amd64 && \
+  # Check if the released binary was modified and make the build fail if it is the case
+  echo "0e24302f71a14518dcc1bcdc6ff8d7da /usr/bin/yaml" | md5sum -c - \
+  || { \
+    echo "ERROR: the [/usr/bin/yaml] binary downloaded from a github release was modified while is should not !!"; \
+    return 1; \
+  } && chmod a+x /usr/bin/yaml
 
 # Build Arguments and environment variables
 ARG EXO_VERSION=4.4.1

--- a/README.md
+++ b/README.md
@@ -57,6 +57,31 @@ The following environment variables can be passed to the container to configure 
 | EXO_HTTP_THREAD_MAX | NO | `200` | maximum number of threads in the tomcat http connector
 | EXO_HTTP_THREAD_MIN | NO | `10` | minimum number of threads ready in the tomcat http connector
 
+### Valves and Listners
+
+A file containing the list of valves and listeners can be attached to the container in the path {{/etc/exo/host.yml}}. If a file is specified, the default valves and listeners configuraiton will be overriden.
+
+The file format is :
+```
+components:
+  - type: Valve
+    className: org.acme.myvalves.WthoutAttributes
+  - type: Valve
+    className: org.acme.myvalves.WthAttributes
+    attributes:
+      - name: param1
+        value: value1
+      - name: param2
+        value: value2
+  - type: Listener
+    className: org.acme.mylistener.WthAttributes
+    attributes:
+      - name: param1
+        value: value1
+      - name: param2
+        value: value2
+```
+
 ## Data on disk
 
 The following environment variables must be passed to the container in order to work :


### PR DESCRIPTION
It uses a yaml config file (see the readme for the format). if the file is mounted on /etc/exo/host.yml the default valve and container configuration is overridden.  If not, the Host section is untouched.

The https://github.com/mikefarah/yaml tool is installed to parse the yaml config file.