### PR TITLE
Use the right ES docker images (for ES 5.3.2)

### DIFF
--- a/test/common-plf50-stack.yml
+++ b/test/common-plf50-stack.yml
@@ -66,7 +66,7 @@ services:
     networks:
       - back
   es:
-    image: exoplatform/elasticsearch:0.3
+    image: exoplatform/elasticsearch:1.0.2
     volumes: 
       - search_data:/usr/share/elasticsearch/data:rw
     networks:


### PR DESCRIPTION
This PR updates the ES docker image version to 1.0.2, for ES 5.3.2, since PLF is not compatible with image 0.3 (ES 2.3).
With this changes, the ES container does not start because of this error :
`max virtual memory areas vm.max_map_count [65530] is too low, increase to at least [262144]`
To make it starts, I had to increase my linux kernel setting vm_max_map_count with :
`sudo sysctl -w vm.max_map_count=262144`
(see https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html#docker-cli-run-prod-mode)