### PR TITLE
DOCKER-7: Support build with custom archives

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,8 @@ ARG DOWNLOAD_URL
 ARG DOWNLOAD_USER
 # allow to override the list of addons to package by default
 ARG ADDONS="exo-chat:1.4.2 exo-tasks:1.2.3 exo-remote-edit:1.2.2"
+# Default base directory on the plf archive
+ARG ARCHIVE_BASE_DIR=platform-${EXO_VERSION}
 
 ENV EXO_APP_DIR     /opt/exo
 ENV EXO_CONF_DIR    /etc/exo
@@ -76,7 +78,7 @@ RUN if [ -n "${DOWNLOAD_USER}" ]; then PARAMS="-u ${DOWNLOAD_USER}"; fi && \
     curl ${PARAMS} -L -o /srv/downloads/eXo-Platform-${EXO_VERSION}.zip ${DOWNLOAD_URL} && \
     unzip -q /srv/downloads/eXo-Platform-${EXO_VERSION}.zip -d /srv/downloads/ && \
     rm -f /srv/downloads/eXo-Platform-${EXO_VERSION}.zip && \
-    mv /srv/downloads/platform-${EXO_VERSION}* ${EXO_APP_DIR} && \
+    mv /srv/downloads/${ARCHIVE_BASE_DIR} ${EXO_APP_DIR} && \
     chown -R ${EXO_USER}:${EXO_GROUP} ${EXO_APP_DIR} && \
     ln -s ${EXO_APP_DIR}/gatein/conf /etc/exo && \
     rm -rf ${EXO_APP_DIR}/logs && ln -s ${EXO_LOG_DIR} ${EXO_APP_DIR}/logs

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ This will produce an image with the current eXo Platform enterprise version and 
 | EXO_VERSION | NO | latest stable version | the full version number of the eXo Platform to package
 | DOWNLOAD_URL | NO | public download url | the full url where the eXo Platform binary must be downloaded
 | DOWNLOAD_USER | NO | - | a username to use for downloading the eXo Platform binary
-
+| ARCHIVE_BASE_DIR | NO | platform-${EXO_VERSION} | Platform directory in the archive used for the installation
 
 If you want to bundle a particular list of add-ons :
 


### PR DESCRIPTION
Add a build variable to specify the plf directory on the archive used for the installation but don't change the default behavior
