### PR TITLE
Add support for standalone chat server

### DIFF
--- a/test/conf/nginx-plf44-chatserver.conf
+++ b/test/conf/nginx-plf44-chatserver.conf
@@ -1,0 +1,104 @@
+user  nginx;
+worker_processes  1;
+
+events {
+    worker_connections  1024;
+}
+http {
+  include           mime.types;
+
+  gzip              on;
+  gzip_proxied      any;
+  gzip_http_version 1.1;
+  gzip_comp_level   6;
+  gzip_types        text/plain text/css text/javascript application/json application/x-javascript text/xml application/xml application/xml+rss;
+  gzip_disable      msie6;
+
+  upstream  exo_app {
+    server  exo:8080;
+  }
+
+  upstream  chatserver {
+    server  chatserver:8080;
+  }
+
+  server {
+    listen 80 default_server;
+    #server_name my.server.name;
+
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+    client_max_body_size 250m;
+
+    #### eXo Platform
+    location / {
+      proxy_pass http://exo_app;
+      # Pass the client informations the the backend
+    }
+    # we limit the file upload size (this upload url is the one for File Explorer)
+    location /portal/rest/wcmDriver/uploadFile/upload {
+      proxy_pass http://exo_app;
+      # we define a max body size to allow file upload
+      # Disable nginx buffering and enforce http 1.1 (ITOP-3253)
+      # source: https://serverfault.com/questions/768693/nginx-how-to-completely-disable-request-body-buffering
+      proxy_http_version 1.1;
+      proxy_request_buffering off;
+    }
+    # we limit the file upload size (this upload url is the one for file selector upload used in the activity stream)
+    location /portal/rest/managedocument/uploadFile/upload {
+      proxy_pass http://exo_app;
+      # we define a max body size to allow file upload
+      # Disable nginx buffering and enforce http 1.1 (ITOP-3253)
+      # source: https://serverfault.com/questions/768693/nginx-how-to-completely-disable-request-body-buffering
+      proxy_http_version 1.1;
+      proxy_request_buffering off;
+    }
+    # we limit the portal upload to 5m for user and space avatar upload
+    location /portal/upload {
+      proxy_pass http://exo_app;
+      client_max_body_size 5m;
+      # Disable nginx buffering and enforce http 1.1 (ITOP-3253)
+      # source: https://serverfault.com/questions/768693/nginx-how-to-completely-disable-request-body-buffering
+      proxy_http_version 1.1;
+      proxy_request_buffering off;
+    }
+    # Websocket for Cometd
+    location /cometd/cometd {
+      proxy_pass http://exo:8080;
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "upgrade";
+    }
+    # standalone chat server configuration
+    location /chatServer {
+      proxy_pass http://chatserver;
+      # Disable nginx buffering and enforce http 1.1 (ITOP-3253)
+      # source: https://serverfault.com/questions/768693/nginx-how-to-completely-disable-request-body-buffering
+      proxy_http_version 1.1;
+      proxy_request_buffering off;
+    }
+    # Websocket for Cometd
+    location /chatServer/cometd {
+      proxy_pass http://chatserver;
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "upgrade";
+    }
+
+
+    #### MailHug
+    # Mail IHM
+    location /mail {
+      proxy_pass http://mail:8025;
+    }
+    # Websocket
+    location /mail/api/v2/websocket {
+      proxy_pass http://mail:8025;
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "upgrade";
+    }
+  }
+}

--- a/test/docker-compose-44-pgsql-chatserver.yml
+++ b/test/docker-compose-44-pgsql-chatserver.yml
@@ -1,0 +1,109 @@
+version: '2'
+services:
+  web:
+    extends:
+      file: common-plf44-stack.yml
+      service: web
+    volumes:
+      - ./conf/nginx-plf44-chatserver.conf:/etc/nginx/nginx.conf:ro
+    ports:
+      - "80:80"
+    links:
+      - exo
+      - chatserver
+    depends_on:
+      - exo
+      - mail
+      - chatserver
+  exo:
+    extends:
+      file: common-plf44-stack.yml
+      service: exo
+    # TODO change this
+    image: exoplatform/exo:DOCKER-18
+    environment:
+      EXO_DB_TYPE: pgsql
+      EXO_ADDONS_CATALOG_URL:
+      EXO_ADDONS_LIST:
+      EXO_ADDONS_REMOVE_LIST:
+      EXO_ES_EMBEDDED: "false"
+      EXO_ES_HOST: search
+      EXO_CHAT_SERVER_STANDALONE: "true"
+      EXO_CHAT_SERVER_URL: http://chatserver:8080
+      EXO_CHAT_SERVER_PASSPHRASE: "mysecretkey"
+      EXO_MONGO_DB_NAME: "exo-chat"
+      # TODO remove
+      EXO_REGISTRATION: "false"
+    ports:
+      # (Linux) open JMX ports for local connection only
+      #- "127.0.0.1:10001:10001"
+      #- "127.0.0.1:10002:10002"
+      # (macOS / Windows) open JMX ports on the host
+      - "10001:10001"
+      - "10002:10002"
+    links:
+      - db
+      - search
+      - chatserver
+    depends_on:
+      - db
+      - search
+      - mail
+      - chatserver
+  chatserver:
+    # TODO use version 1.5.0
+    image: exoplatform/chat-server:latest
+    environment:
+      CHAT_PASSPHRASE: "mysecretkey"
+      CHAT_MONGO_DB_NAME: "exo-chat"
+      CHAT_SMTP_HOST: "mail"
+      CHAT_SMTP_PORT: "1025"
+      CHAT_SMTP_FROM: chat@test.com
+    links:
+      - mongo
+    expose:
+      - 8080
+    depends_on:
+      - mongo
+    networks:
+      - front
+      - back
+      - mail
+  mongo:
+    extends:
+      file: common-plf44-stack.yml
+      service: mongo
+  db:
+    extends:
+      file: common-plf44-stack.yml
+      service: pgsql
+  search:
+    extends:
+      file: common-plf44-stack.yml
+      service: es
+    ports:
+      # (Linux) open elasticsearch port for local connection only
+      #- "127.0.0.1:9200:9200"
+      # (macOS / Windows) open elasticsearch port for local connection only
+      - "9200:9200"
+  mail:
+    extends:
+      file: common-plf44-stack.yml
+      service: mail
+    depends_on:
+      - mongo
+volumes:
+  exo_data:
+  exo_logs:
+  db_data:
+  mongo_data:
+  search_data:
+networks:
+  front:
+  back:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: 192.168.1.0/24
+  mail:


### PR DESCRIPTION
- Configure only useful parameter
- Don't wait for mongo if chat server standalone is used
- Don't generate a random chat passphrase with standalone chat server
- Add a docker-compose for test