### PR TITLE
DOCKER-18 : allow to deploy chat server standalone on the exo image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN echo "deb http://archive.ubuntu.com/ubuntu $(lsb_release -cs)-backports main
   && echo "deb http://archive.ubuntu.com/ubuntu $(lsb_release -cs)-updates main universe multiverse restricted" >> /etc/apt/sources.list
 RUN apt-get -qq update && \
   apt-get -qq -y upgrade ${_APT_OPTIONS} && \
-  apt-get -qq -y install ${_APT_OPTIONS} xmlstarlet && \
+  apt-get -qq -y install ${_APT_OPTIONS} xmlstarlet jq && \
   echo "ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true" | debconf-set-selections && \
   echo "ttf-mscorefonts-installer msttcorefonts/present-mscorefonts-eula note" | debconf-set-selections && \
   apt-get -qq -y install ${_APT_OPTIONS} ttf-mscorefonts-installer && \
@@ -39,6 +39,7 @@ RUN wget -q -O /usr/bin/yaml https://github.com/mikefarah/yaml/releases/download
 
 # Build Arguments and environment variables
 ARG EXO_VERSION=5.0.0-RC04
+
 # this allow to specify an eXo Platform download url
 ARG DOWNLOAD_URL
 # this allow to specifiy a user to download a protected binary

--- a/test/conf/nginx-plf44-node1.conf
+++ b/test/conf/nginx-plf44-node1.conf
@@ -68,7 +68,7 @@ http {
       proxy_set_header Connection "upgrade";
     }
 
-    #### MailHug
+    #### MailHog
     # Mail IHM
     location /mail {
       proxy_pass http://mail:8025;

--- a/test/conf/nginx-plf44-node2.conf
+++ b/test/conf/nginx-plf44-node2.conf
@@ -68,7 +68,7 @@ http {
       proxy_set_header Connection "upgrade";
     }
 
-    #### MailHug
+    #### MailHog
     # Mail IHM
     location /mail {
       proxy_pass http://mail:8025;

--- a/test/conf/nginx-plf50-chatserver.conf
+++ b/test/conf/nginx-plf50-chatserver.conf
@@ -2,11 +2,11 @@ user  nginx;
 worker_processes  1;
 
 events {
-    worker_connections  256;
+    worker_connections  1024;
 }
 http {
   include           mime.types;
-  
+
   gzip              on;
   gzip_proxied      any;
   gzip_http_version 1.1;
@@ -18,6 +18,10 @@ http {
     server  exo:8080;
   }
 
+  upstream  chatserver {
+    server  chatserver:8080;
+  }
+
   server {
     listen 80 default_server;
     #server_name my.server.name;
@@ -26,7 +30,7 @@ http {
     proxy_set_header Host $host;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
-    client_max_body_size 250m;  
+    client_max_body_size 250m;
 
     #### eXo Platform
     location / {
@@ -62,11 +66,27 @@ http {
     }
     # Websocket for Cometd
     location /cometd/cometd {
-      proxy_pass http://exo_app;
+      proxy_pass http://exo:8080;
       proxy_http_version 1.1;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection "upgrade";
     }
+    # standalone chat server configuration
+    location /chatServer {
+      proxy_pass http://chatserver;
+      # Disable nginx buffering and enforce http 1.1 (ITOP-3253)
+      # source: https://serverfault.com/questions/768693/nginx-how-to-completely-disable-request-body-buffering
+      proxy_http_version 1.1;
+      proxy_request_buffering off;
+    }
+    # Websocket for Cometd
+    location /chatServer/cometd {
+      proxy_pass http://chatserver;
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "upgrade";
+    }
+
 
     #### MailHog
     # Mail IHM

--- a/test/conf/nginx-plf50.conf
+++ b/test/conf/nginx-plf50.conf
@@ -68,7 +68,7 @@ http {
       proxy_set_header Connection "upgrade";
     }
 
-    #### MailHug
+    #### MailHog
     # Mail IHM
     location /mail {
       proxy_pass http://mail:8025;

--- a/test/docker-compose-50-pgsql-chatserver.yml
+++ b/test/docker-compose-50-pgsql-chatserver.yml
@@ -1,0 +1,100 @@
+version: '2'
+services:
+  web:
+    extends:
+      file: common-plf50-stack.yml
+      service: web
+    volumes:
+      - ./conf/nginx-plf50-chatserver.conf:/etc/nginx/nginx.conf:ro
+    ports:
+      - "80:80"
+    links:
+      - exo
+      - chatserver
+    depends_on:
+      - exo
+      - mail
+      - chatserver
+  exo:
+    extends:
+      file: common-plf50-stack.yml
+      service: exo
+    image: exoplatform/exo:5.0_latest
+    environment:
+      EXO_DB_TYPE: pgsql
+      EXO_ADDONS_CATALOG_URL:
+      EXO_ADDONS_LIST:
+      EXO_ADDONS_REMOVE_LIST:
+      EXO_ES_EMBEDDED: "false"
+      EXO_ES_HOST: search
+      EXO_CHAT_SERVER_STANDALONE: "true"
+      EXO_CHAT_SERVER_URL: http://chatserver:8080
+      EXO_CHAT_SERVER_PASSPHRASE: "mysecretkey"
+      EXO_MONGO_DB_NAME: "exo-chat"
+    ports:
+      # (Linux) open JMX ports for local connection only
+      #- "127.0.0.1:10001:10001"
+      #- "127.0.0.1:10002:10002"
+      # (macOS / Windows) open JMX ports on the host
+      - "10001:10001"
+      - "10002:10002"
+    links:
+      - db
+      - search
+      - chatserver
+    depends_on:
+      - db
+      - search
+      - mail
+      - chatserver
+  chatserver:
+    image: exoplatform/chat-server:1.6.0_latest
+    environment:
+      CHAT_PASSPHRASE: "mysecretkey"
+      CHAT_MONGO_DB_NAME: "exo-chat"
+      CHAT_SMTP_HOST: "mail"
+      CHAT_SMTP_PORT: "1025"
+      CHAT_SMTP_FROM: chat@test.com
+    links:
+      - mongo
+    expose:
+      - 8080
+    depends_on:
+      - mongo
+    networks:
+      - front
+      - back
+      - mail
+  mongo:
+    extends:
+      file: common-plf50-stack.yml
+      service: mongo
+  db:
+    extends:
+      file: common-plf50-stack.yml
+      service: pgsql
+  search:
+    extends:
+      file: common-plf50-stack.yml
+      service: es
+    ports:
+      # (Linux) open elasticsearch port for local connection only
+      #- "127.0.0.1:9200:9200"
+      # (macOS / Windows) open elasticsearch port for local connection only
+      - "9200:9200"
+  mail:
+    extends:
+      file: common-plf50-stack.yml
+      service: mail
+    depends_on:
+      - mongo
+volumes:
+  exo_data:
+  exo_logs:
+  db_data:
+  mongo_data:
+  search_data:
+networks:
+  front:
+  back:
+  mail:


### PR DESCRIPTION
Replacement of the [previous PR for chat-server](https://github.com/exo-docker/exo/pull/8). This one is based on the 5.0 as the standalone chat server image is only available for the 1.6.0.

* Configure only useful parameter
* Don't wait for mongo if chat server standalone is used
* Don't generate a random chat passphrase with standalone chat server
* Add a docker-compose for test

The changes requested on the first review are applied