### PR TITLE
Fix license file path

### DIFF
--- a/bin/setenv-docker-customize.sh
+++ b/bin/setenv-docker-customize.sh
@@ -705,7 +705,7 @@ fi
 # -----------------------------------------------------------------------------
 # Define a better place for eXo Platform license file
 # -----------------------------------------------------------------------------
-CATALINA_OPTS="${CATALINA_OPTS:-} -Dexo.license.path=/etc/exo/license.xml"
+CATALINA_OPTS="${CATALINA_OPTS:-} -Dexo.license.path=/etc/exo"
 
 # -----------------------------------------------------------------------------
 # LDAP configuration


### PR DESCRIPTION
Since version 5.3.5, eXo does not recognize the stored license file due to the automatic concatenation of the license file name "**license.xml**" on the product side.

**Affected versions:**
- 5.3.x ( 5.3.5 +)
- 6.0.x
- 6.1.x (develop)