### PR TITLE
Fix newly introduced variables initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ The following environment variables must be passed to the container in order to 
 | -------------------------- | --------- | ---------------------------- | ------------------------------------------------------------------------------------------------------|
 | EXO_DATA_DIR               | NO        | `/srv/exo`                   | the directory to store eXo Platform data                                                              |
 | EXO_JCR_STORAGE_DIR        | NO        | `${EXO_DATA_DIR}/jcr/values` | the directory to store eXo Platform JCR values data                                                   |
-| EXO_JCR_DB_STORAGE_ENABLED | NO        | Default value of eXo Server  | Whether to store JCR Binary files in RDBMS or File system. Possible values: true (=FS) OR false (=DB) |
+| EXO_JCR_FS_STORAGE_ENABLED | NO        | Default value of eXo Server  | Whether to store JCR Binary files in RDBMS or File system. Possible values: true (=FS) OR false (=DB) |
 | EXO_FILE_STORAGE_DIR       | NO        | `${EXO_DATA_DIR}/files`      | the directory to store eXo Platform data                                                              |
 | EXO_FILE_STORAGE_TYPE      | NO        | Default value of eXo Server  | Whether to store Files API Binary files in RDBMS or File system. Possible values: rdbms OR fs         |
 | EXO_FILE_STORAGE_RETENTION | NO        | `30`                         | the number of days to keep deleted files on disk before definitively remove it from the disk          |

--- a/bin/setenv-docker-customize.sh
+++ b/bin/setenv-docker-customize.sh
@@ -143,6 +143,7 @@ esac
 
 [ -z "${EXO_CHAT_SERVER_STANDALONE}" ] && EXO_CHAT_SERVER_STANDALONE="false"
 [ -z "${EXO_CHAT_SERVER_URL}" ] && EXO_CHAT_SERVER_URL="http://localhost:8080"
+[ -z "${EXO_CHAT_SERVICE_URL}" ] && EXO_CHAT_SERVICE_URL=""
 [ -z "${EXO_CHAT_SERVER_PASSPHRASE}" ] && EXO_CHAT_SERVER_PASSPHRASE="something2change"
 
 [ -z "${EXO_ES_EMBEDDED}" ] && EXO_ES_EMBEDDED="true"
@@ -175,6 +176,11 @@ EXO_ES_URL="${EXO_ES_SCHEME}://${EXO_ES_HOST}:${EXO_ES_PORT}"
 
 [ -z "${EXO_ADDONS_CONFLICT_MODE}" ] && EXO_ADDONS_CONFLICT_MODE=""
 
+[ -z "${EXO_JCR_FS_STORAGE_ENABLED}" ] && EXO_JCR_FS_STORAGE_ENABLED=""
+[ -z "${EXO_FILE_STORAGE_TYPE}" ] && EXO_FILE_STORAGE_TYPE=""
+
+[ -z "${EXO_CLUSTER_NODE_NAME}" ] && EXO_CLUSTER_NODE_NAME=""
+
 set -u		# REACTIVATE unbound variable check
 
 # -----------------------------------------------------------------------------
@@ -186,8 +192,8 @@ else
 
   # Jcr storage configuration
   add_in_exo_configuration "# JCR storage configuration"
-  if [ ! -z ${EXO_JCR_DB_STORAGE_ENABLED} ]; then
-    add_in_exo_configuration "exo.jcr.storage.enabled=${EXO_JCR_DB_STORAGE_ENABLED}"
+  if [ ! -z ${EXO_JCR_FS_STORAGE_ENABLED} ]; then
+    add_in_exo_configuration "exo.jcr.storage.enabled=${EXO_JCR_FS_STORAGE_ENABLED}"
   fi
   add_in_exo_configuration "exo.jcr.storage.data.dir=${EXO_JCR_STORAGE_DIR}"
 


### PR DESCRIPTION
The variables `EXO_CHAT_SERVICE_URL`, `EXO_JCR_FS_STORAGE_ENABLED`, `EXO_FILE_STORAGE_TYPE` and `EXO_CLUSTER_NODE_NAME` were newly introduced but it mustn't be mandatory. Thus its default value should be `""` (EMPTY String).
In addition, the name of old variable `EXO_JCR_DB_STORAGE_ENABLED` should be `EXO_JCR_FS_STORAGE_ENABLED` instead, beacause when the value equals to true, it enables FS value storage, else it will be in RDBMS.