### PR TITLE
Add possibility to specify TLS version for emails sending

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,8 @@ The following environment variables should be passed to the container in order t
 | EXO_MAIL_SMTP_STARTTLS | NO        | `false`                   | true to enable the secure (TLS) SMTP. See RFC 3207. |
 | EXO_MAIL_SMTP_USERNAME | NO        | -                         | authentication username for smtp server (if needed) |
 | EXO_MAIL_SMTP_PASSWORD | NO        | -                         | authentication password for smtp server (if needed) |
+| EXO_SMTP_SSL_PROTOCOLS | NO        | -                         | tls version for smtp server (if needed) |
+
 
 ### JMX
 

--- a/bin/setenv-docker-customize.sh
+++ b/bin/setenv-docker-customize.sh
@@ -408,7 +408,10 @@ else
   fi
   add_in_exo_configuration "exo.email.smtp.socketFactory.port="
   add_in_exo_configuration "exo.email.smtp.socketFactory.class="
-
+  # SMTP TLS Version, Example: TLSv1.2
+  if [ ! -z "${EXO_SMTP_SSL_PROTOCOLS:-}" ]; then 
+    add_in_exo_configuration "mail.smtp.ssl.protocols=${EXO_SMTP_SSL_PROTOCOLS}"
+  fi
   # JMX configuration
   if [ "${EXO_JMX_ENABLED}" = "true" ]; then
     # insert the listener before the "Global JNDI resources" line


### PR DESCRIPTION
With JDK 11 version, in some cases we need to specifiy the TLS version as legacy ones are deprecated.