### PR TITLE
feat: Remove libreoffice packages due to jodconverter removal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,6 @@ RUN apt-get -qq update && \
   echo "ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true" | debconf-set-selections && \
   echo "ttf-mscorefonts-installer msttcorefonts/present-mscorefonts-eula note" | debconf-set-selections && \
   apt-get -qq -y install ${_APT_OPTIONS} ttf-mscorefonts-installer && \
-  apt-get -qq -y install ${_APT_OPTIONS} libreoffice-calc libreoffice-draw libreoffice-impress libreoffice-math libreoffice-writer && \
   apt-get -qq -y autoremove && \
   apt-get -qq -y clean && \
   rm -rf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ The image is compatible with the following databases system :  `MySQL` (default)
     - [standalone](#standalone)
   - [ElasticSearch](#elasticsearch)
   - [LDAP / Active Directory](#ldap--active-directory)
-  - [JOD Converter](#jod-converter)
   - [Mail](#mail)
   - [JMX](#jmx)
   - [Remote Debugging](#remote-debugging)
@@ -267,14 +266,6 @@ The following environment variables should be passed to the container in order t
 | EXO_LDAP_POOL_DEBUG    | NO        | -             | the level of debug output to produce. Valid values are "fine" (trace connection creation and removal) and "all" (all debugging information). |
 | EXO_LDAP_POOL_TIMEOUT  | NO        | `60000`       | the number of milliseconds that an idle connection may remain in the pool without being closed and removed from the pool.                    |
 | EXO_LDAP_POOL_MAX_SIZE | NO        | `100`         | the maximum number of connections per connection identity that can be maintained concurrently.                                               |
-
-### JOD Converter
-
-The following environment variables should be passed to the container in order to configure jodconverter :
-
-| VARIABLE               | MANDATORY | DEFAULT VALUE | DESCRIPTION                                                                               |
-| ---------------------- | --------- | ------------- | ----------------------------------------------------------------------------------------- |
-| EXO_JODCONVERTER_PORTS | NO        | `2002`        | comma separated list of ports to allocate to JOD Converter processes (ex: 2002,2003,2004) |
 
 ### Mail
 

--- a/bin/setenv-docker-customize.sh
+++ b/bin/setenv-docker-customize.sh
@@ -167,8 +167,6 @@ EXO_ES_URL="${EXO_ES_SCHEME}://${EXO_ES_HOST}:${EXO_ES_PORT}"
 [ -z "${EXO_LDAP_POOL_TIMEOUT}" ] && EXO_LDAP_POOL_TIMEOUT="60000"
 [ -z "${EXO_LDAP_POOL_MAX_SIZE}" ] && EXO_LDAP_POOL_MAX_SIZE="100"
 
-[ -z "${EXO_JODCONVERTER_PORTS}" ] && EXO_JODCONVERTER_PORTS="2002"
-
 [ -z "${EXO_REGISTRATION}" ] && EXO_REGISTRATION="true"
 
 [ -z "${EXO_PROFILES}" ] && EXO_PROFILES="all"
@@ -495,9 +493,6 @@ else
 
   add_in_exo_configuration "exo.es.indexing.replica.number.default=${EXO_ES_INDEX_REPLICA_NB}"
   add_in_exo_configuration "exo.es.indexing.shard.number.default=${EXO_ES_INDEX_SHARD_NB}"
-
-  # JOD Converter
-  add_in_exo_configuration "exo.jodconverter.portnumbers=${EXO_JODCONVERTER_PORTS}"
 
   if [ "${EXO_REGISTRATION}" = "false" ]; then
     add_in_exo_configuration "# Registration"


### PR DESCRIPTION
Jodconverter feature was removed from eXo. Hence, there is no more needed to install debian libreoffice packages