### PR TITLE
Fix ENV directive deprecration notice

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,15 +45,15 @@ ARG ADDONS="exo-jdbc-driver-mysql:2.0.5 exo-jdbc-driver-postgresql:2.4.1"
 # Default base directory on the plf archive
 ARG ARCHIVE_BASE_DIR=platform-${EXO_VERSION}
 
-ENV EXO_APP_DIR            /opt/exo
-ENV EXO_CONF_DIR           /etc/exo
-ENV EXO_DATA_DIR           /srv/exo
-ENV EXO_SHARED_DATA_DIR    /srv/exo/shared
-ENV EXO_LOG_DIR            /var/log/exo
-ENV EXO_TMP_DIR            /tmp/exo-tmp
+ENV EXO_APP_DIR=/opt/exo
+ENV EXO_CONF_DIR=/etc/exo
+ENV EXO_DATA_DIR=/srv/exo
+ENV EXO_SHARED_DATA_DIR=/srv/exo/shared
+ENV EXO_LOG_DIR=/var/log/exo
+ENV EXO_TMP_DIR=/tmp/exo-tmp
 
-ENV EXO_USER exo
-ENV EXO_GROUP ${EXO_USER}
+ENV EXO_USER=exo
+ENV EXO_GROUP=${EXO_USER}
 
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 # (we use 999 as uid like in official Docker images)


### PR DESCRIPTION
Fix warning: LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value"