### PR TITLE
fix: fix codec persistence and add codec volume to test docker-compose PLF 7.0.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ ARG ARCHIVE_BASE_DIR=platform-${EXO_VERSION}
 
 ENV EXO_APP_DIR=/opt/exo
 ENV EXO_CONF_DIR=/etc/exo
+ENV EXO_CODEC_DIR=/etc/exo/codec
 ENV EXO_DATA_DIR=/srv/exo
 ENV EXO_SHARED_DATA_DIR=/srv/exo/shared
 ENV EXO_LOG_DIR=/var/log/exo
@@ -74,6 +75,7 @@ RUN if [ -n "${DOWNLOAD_USER}" ]; then PARAMS="-u ${DOWNLOAD_USER}"; fi && \
   mv /srv/downloads/${ARCHIVE_BASE_DIR} ${EXO_APP_DIR} && \
   chown -R ${EXO_USER}:${EXO_GROUP} ${EXO_APP_DIR} && \
   ln -s ${EXO_APP_DIR}/gatein/conf /etc/exo && \
+  mkdir -p ${EXO_CODEC_DIR} && chown ${EXO_USER}:${EXO_GROUP} ${EXO_CODEC_DIR} && \
   rm -rf ${EXO_APP_DIR}/logs && ln -s ${EXO_LOG_DIR} ${EXO_APP_DIR}/logs
 
 # Install Docker customization file

--- a/test/common-plf70-stack.yml
+++ b/test/common-plf70-stack.yml
@@ -35,6 +35,7 @@ services:
       - "8080"
     volumes:
       - exo_data:/srv/exo
+      - exo_codec:/etc/exo/codec
       - exo_logs:/var/log/exo
     networks:
       - front

--- a/test/docker-compose-70-mysql.yml
+++ b/test/docker-compose-70-mysql.yml
@@ -63,6 +63,7 @@ services:
       - mongo
 volumes:
   exo_data:
+  exo_codec:
   exo_logs:
   db_data:
   mongo_data:

--- a/test/docker-compose-70-pgsql.yml
+++ b/test/docker-compose-70-pgsql.yml
@@ -63,6 +63,7 @@ services:
       - mongo
 volumes:
   exo_data:
+  exo_codec:
   exo_logs:
   db_data:
   mongo_data:


### PR DESCRIPTION
Before this fix, the codec key file was managed externally by a Docker orchestrator, such as Docker Compose, with explicit file permissions to host the file. This change introduces native support for codec persistence within the Docker image. This PR will also add exo_codec docker volume to compose test files for eXo Platform 7.0.x.

_(fix backported from meeds-io due to hsqldb persistence issue)_