### PR TITLE
Enhance EXO self-signed certificate handling based on certificate hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,9 +316,10 @@ The following environment variables should be passed to the container in order t
 
 The following environment variables should be passed to the container in order to import self-signed certficates :
 
-| VARIABLE                    | MANDATORY | DEFAULT VALUE | DESCRIPTION                                                                                                                               |
-| --------------------------- | --------- | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| EXO_SELFSIGNEDCERTS_HOSTS   | NO        | -       | commas separated list of self-certificates hostname to import to keystore           |
+| VARIABLE                          | MANDATORY | DEFAULT VALUE | DESCRIPTION                                                                                                                                                         |
+| --------------------------------- | --------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| EXO_SELFSIGNEDCERTS_HOSTS         | NO        | -             | commas separated list of self-certificates hostname to import to keystore                               |
+| EXO_SELFSIGNEDCERTS_STRICT_MODE   | NO        | `false`       | Strict mode for importing certificates (Abort the server startup if ssl certificate import fails) |
 
 ### Rememberme Token Expiration
 


### PR DESCRIPTION
This update introduces a mechanism to verify the certificate hash at each server startup. The certificate is automatically imported at the first startup and its hash is saved. At subsequent startups, the hash is checked for changes. If the hash differs, the certificate is updated. Regarding an SSL retrieval error, two modes are available: strict and non-strict. In both modes, if the retrieval fails for the first time, the server startup is aborted. In non-strict mode, the server will continue with the current certificate even if the retrieval fails.